### PR TITLE
feat(query, receive, rule, store): add tls config on gRPC servers

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -32,6 +32,8 @@ local defaults = {
   telemetryDurationQuantiles: '',
   telemetrySamplesQuantiles: '',
   telemetrySeriesQuantiles: '',
+  tlsCipherSuites: '',
+  tlsMinVersion: '',
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-query',
@@ -190,6 +192,14 @@ function(params) {
         ) + (
           if tq.config.queryUrl != '' then [
             '--alert.query-url=' + tq.config.queryUrl,
+          ] else []
+        ) + (
+          if std.length(tq.config.tlsCipherSuites) > 0 then [
+            '--grpc-server-tls-ciphers=' + tq.config.tlsCipherSuites,
+          ] else []
+        ) + (
+          if std.length(tq.config.tlsMinVersion) > 0 then [
+            '--grpc-server-tls-min-version=' + tq.config.tlsMinVersion,
           ] else []
         ),
       env: [

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -37,6 +37,8 @@
   extraEnv: [],
   receiveLimitsConfigFile: {},
   storeLimits: {},
+  tlsCipherSuites: '',
+  tlsMinVersion: '',
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-receive',

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -115,6 +115,22 @@ function(params) {
           '--receive.limits-config-file=/etc/thanos/config/' + tr.config.receiveLimitsConfigFile.name + '/' + tr.config.receiveLimitsConfigFile.key,
         ]
         else []
+      ) + (
+        if std.length(tr.config.tlsCipherSuites) > 0 then [
+          '--grpc-server-tls-ciphers=' + tr.config.tlsCipherSuites,
+        ] else []
+      ) + (
+        if std.length(tr.config.tlsMinVersion) > 0 then [
+          '--grpc-server-tls-min-version=' + tr.config.tlsMinVersion,
+        ] else []
+      ) + (
+        if std.length(tr.config.tlsCipherSuites) > 0 then [
+          '--remote-write.server-tls-ciphers=' + tr.config.tlsCipherSuites,
+        ] else []
+      ) + (
+        if std.length(tr.config.tlsMinVersion) > 0 then [
+          '--remote-write.server-tls-min-version=' + tr.config.tlsMinVersion,
+        ] else []
       ),
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -32,6 +32,8 @@ local defaults = {
   },
   tracing: {},
   extraEnv: [],
+  tlsCipherSuites: '',
+  tlsMinVersion: '',
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-rule',
@@ -166,6 +168,14 @@ function(params) {
             '--remote-write.config-file=/etc/thanos/config/' + tr.config.remoteWriteConfigFile.name + '/' + tr.config.remoteWriteConfigFile.key,
           ]
           else []
+        ) + (
+          if std.length(tr.config.tlsCipherSuites) > 0 then [
+            '--grpc-server-tls-ciphers=' + tr.config.tlsCipherSuites,
+          ] else []
+        ) + (
+          if std.length(tr.config.tlsMinVersion) > 0 then [
+            '--grpc-server-tls-min-version=' + tr.config.tlsMinVersion,
+          ] else []
         ),
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -36,6 +36,8 @@
   minTime: '',
   maxTime: '',
   extraEnv: [],
+  tlsCipherSuites: '',
+  tlsMinVersion: '',
 
   memcachedDefaults+:: {
     config+: {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -115,6 +115,14 @@ function(params) {
             { config+: { service_name: defaults.name } } + ts.config.tracing
           ),
         ] else []
+      ) + (
+        if std.length(ts.config.tlsCipherSuites) > 0 then [
+          '--grpc-server-tls-ciphers=' + ts.config.tlsCipherSuites,
+        ] else []
+      ) + (
+        if std.length(ts.config.tlsMinVersion) > 0 then [
+          '--grpc-server-tls-min-version=' + ts.config.tlsMinVersion,
+        ] else []
       ),
       env: [
         {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Propagate `tlsCipherSuites` and `tlsMinVersion` to gRPC servers supporting it. Affected fields: --grpc-server-tls-min-version, --grpc-server-tls-ciphers, --remote-write.server-tls-ciphers, and --remote-write.server-tls-min-version=
